### PR TITLE
enable on macOS non-ssh

### DIFF
--- a/plugin/fcitx.vim
+++ b/plugin/fcitx.vim
@@ -5,7 +5,7 @@ scriptencoding utf-8
 " URL:		https://www.vim.org/scripts/script.php?script_id=3764
 " ---------------------------------------------------------------------
 " Load Once:
-if &cp || exists("g:loaded_fcitx") || (!exists('$DISPLAY') && !exists('$WAYLAND_DISPLAY'))
+if &cp || exists("g:loaded_fcitx") || (!exists('$DISPLAY') && !exists('$WAYLAND_DISPLAY') && !(has('mac') && !exists('$SSH_TTY')))
   finish
 endif
 let s:keepcpo = &cpo
@@ -33,7 +33,7 @@ function s:setup_cmd()
   let g:loaded_fcitx = 1
 endfunction
 
-" If g:fcitx5_remote is set (to the path to `fcitx5-remove`), use it to toggle IME state.
+" If g:fcitx5_remote is set (to the path to `fcitx5-remote`), use it to toggle IME state.
 if exists("g:fcitx5_remote")
   call s:setup_cmd()
 


### PR DESCRIPTION
[Fcitx5 macOS](https://github.com/fcitx-contrib/fcitx5-macos) starts to support a subset of fcitx5-remote commands that can be used by fcitx.vim.

~/.vimrc
```vim
let g:fcitx5_remote = '"/Library/Input Methods/Fcitx5.app/Contents/bin/fcitx5-remote"'
set ttimeoutlen=100
```

https://github.com/user-attachments/assets/c2d88781-d6d7-4700-b773-b85a5c16842a